### PR TITLE
failure example

### DIFF
--- a/test_mem.rb
+++ b/test_mem.rb
@@ -13,7 +13,8 @@ class AtomicJob
   sidekiq_options queue: 'test_queue', retry: 0
 
   def perform(account_id)
-    #raise 'test error' if account_id.to_s == '49999' # simulate error if needed
+    puts "RUNNING JOB: #{account_id}"
+    raise 'test error' if account_id.to_s == '3' # simulate error if needed
   end
 end
 
@@ -32,24 +33,24 @@ class BatchJob
     batch = Sidekiq::Batch.new
     batch.on(:complete, BatchCallback)
     batch.jobs do
-      # AFTER (using bulk)
-      #
-      (1..NUMBER_OF_JOBS).to_a.each_slice(1000) do |batch|
-        account_id_batch = batch.map {|id| [id] }
-        Sidekiq::Client.push_bulk('class' => AtomicJob, 'args' => account_id_batch)
+      if ENV['PUSH_BULK']
+        puts 'USING BULK PUSH'
+        (1..NUMBER_OF_JOBS).to_a.each_slice(1000) do |batch|
+          account_id_batch = batch.map {|id| [id] }
+          Sidekiq::Client.push_bulk('class' => AtomicJob, 'args' => account_id_batch)
+        end
+      else
+        puts 'USING INDIVIDUAL PUSH'
+        (1..NUMBER_OF_JOBS).each do |account_id|
+          AtomicJob.perform_async(account_id)
+        end
       end
-
-      # BEFORE (atomic)
-      #
-      # (1..NUMBER_OF_JOBS).each do |account_id|
-      #   AtomicJob.perform_async(account_id)
-      # end
     end
   end
 end
 
 Sidekiq.redis(&:flushdb) # remove any junk
-Sidekiq.logger.level = Logger::DEBUG # set log level
+Sidekiq.logger.level = Logger::INFO # set log level
 
 # enabling memory profiler will affect process memory
 if ENV['MEMORY_PROFILER']


### PR DESCRIPTION
job with id == 3 will raise error

with individual jobs:
```shell
NUMBER_OF_JOBS=5 bundle exec sidekiq -c 1 -r ./test_mem.rb -q test_queue
```
```ruby
2021-01-04T22:55:25.726Z pid=26667 tid=ov1ughf3f class=BatchJob jid=3339ff0a15827dfa36c43ffd INFO: start
USING INDIVIDUAL PUSH
2021-01-04T22:55:25.728Z pid=26667 tid=ov1ughf3f class=BatchJob jid=3339ff0a15827dfa36c43ffd elapsed=0.002 INFO: done
2021-01-04T22:55:25.728Z pid=26667 tid=ov1ughf3f class=AtomicJob jid=9b3f8bc3385591299dbaaa1a bid=xM3w36yVBFZAng INFO: start
RUNNING JOB: 1
2021-01-04T22:55:25.729Z pid=26667 tid=ov1ughf3f class=AtomicJob jid=9b3f8bc3385591299dbaaa1a bid=xM3w36yVBFZAng elapsed=0.001 INFO: done
2021-01-04T22:55:25.730Z pid=26667 tid=ov1ughf3f class=AtomicJob jid=3f26c756d5501273f9cc785c bid=xM3w36yVBFZAng INFO: start
RUNNING JOB: 2
2021-01-04T22:55:25.731Z pid=26667 tid=ov1ughf3f class=AtomicJob jid=3f26c756d5501273f9cc785c bid=xM3w36yVBFZAng elapsed=0.0 INFO: done
2021-01-04T22:55:25.732Z pid=26667 tid=ov1ughf3f class=AtomicJob jid=2ed4b0865ee65abf453a14cc bid=xM3w36yVBFZAng INFO: start
RUNNING JOB: 3
2021-01-04T22:55:25.732Z pid=26667 tid=ov1ughf3f class=AtomicJob jid=2ed4b0865ee65abf453a14cc bid=xM3w36yVBFZAng INFO: Adding dead AtomicJob job 2ed4b0865ee65abf453a14cc
2021-01-04T22:55:25.734Z pid=26667 tid=ov1ughf3f class=AtomicJob jid=2ed4b0865ee65abf453a14cc bid=xM3w36yVBFZAng elapsed=0.003 INFO: fail
2021-01-04T22:55:25.734Z pid=26667 tid=ov1ughf3f WARN: RuntimeError: test error
2021-01-04T22:55:25.735Z pid=26667 tid=ov1u7u4df class=AtomicJob jid=aa8003b4a40e7fd4adab146b bid=xM3w36yVBFZAng INFO: start
RUNNING JOB: 4
2021-01-04T22:55:25.736Z pid=26667 tid=ov1u7u4df class=AtomicJob jid=aa8003b4a40e7fd4adab146b bid=xM3w36yVBFZAng elapsed=0.001 INFO: done
2021-01-04T22:55:25.736Z pid=26667 tid=ov1u7u4df class=AtomicJob jid=b7f15780ac3778964b276e2e bid=xM3w36yVBFZAng INFO: start
RUNNING JOB: 5
2021-01-04T22:55:25.740Z pid=26667 tid=ov1u7u4df class=AtomicJob jid=b7f15780ac3778964b276e2e bid=xM3w36yVBFZAng elapsed=0.004 INFO: done
2021-01-04T22:55:25.740Z pid=26667 tid=ov1u7u4df class=Sidekiq::Batch::Callback jid=f771754d92572afe5c858a89 INFO: start
2021-01-04T22:55:25.740Z pid=26667 tid=ov1u7u4df class=Sidekiq::Batch::Callback jid=f771754d92572afe5c858a89 elapsed=0.0 INFO: done
2021-01-04T22:55:25.740Z pid=26667 tid=ov1u7u4df class=Sidekiq::Batch::Callback jid=bfd631b5c74d7c9f869ce6b3 INFO: start
FINISHED ALL JOBS: running garbage collection
2021-01-04T22:55:25.750Z pid=26667 tid=ov1u7u4df class=Sidekiq::Batch::Callback jid=bfd631b5c74d7c9f869ce6b3 elapsed=0.009 INFO: done
```

with bulk jobs:
```shell
PUSH_BULK=true NUMBER_OF_JOBS=5 bundle exec sidekiq -c 1 -r ./test_mem.rb -q test_queue
```
```ruby
2021-01-04T22:57:58.538Z pid=27170 tid=oumueu0qa class=BatchJob jid=5a22edad56a7c24a394ed66b INFO: start
USING BULK PUSH
2021-01-04T22:57:58.539Z pid=27170 tid=oumueu0qa class=BatchJob jid=5a22edad56a7c24a394ed66b elapsed=0.002 INFO: done
2021-01-04T22:57:58.540Z pid=27170 tid=oumueu0qa class=AtomicJob jid=985498d1224b03ebdf2d85e6 bid=jl82Q49lVs0oOg INFO: start
RUNNING JOB: 1
2021-01-04T22:57:58.541Z pid=27170 tid=oumueu0qa class=AtomicJob jid=985498d1224b03ebdf2d85e6 bid=jl82Q49lVs0oOg elapsed=0.001 INFO: done
2021-01-04T22:57:58.541Z pid=27170 tid=oumueu0qa class=AtomicJob jid=69957a1ef3bb1353ec82eb4a bid=jl82Q49lVs0oOg INFO: start
RUNNING JOB: 2
2021-01-04T22:57:58.542Z pid=27170 tid=oumueu0qa class=AtomicJob jid=69957a1ef3bb1353ec82eb4a bid=jl82Q49lVs0oOg elapsed=0.001 INFO: done
2021-01-04T22:57:58.542Z pid=27170 tid=oumueu0qa class=AtomicJob jid=c24558ca9e6be6b6bc985eb3 bid=jl82Q49lVs0oOg INFO: start
RUNNING JOB: 3
2021-01-04T22:57:58.543Z pid=27170 tid=oumueu0qa class=AtomicJob jid=c24558ca9e6be6b6bc985eb3 bid=jl82Q49lVs0oOg INFO: Adding dead AtomicJob job c24558ca9e6be6b6bc985eb3
2021-01-04T22:57:58.545Z pid=27170 tid=oumueu0qa class=AtomicJob jid=c24558ca9e6be6b6bc985eb3 bid=jl82Q49lVs0oOg elapsed=0.003 INFO: fail
2021-01-04T22:57:58.545Z pid=27170 tid=oumueu0qa WARN: RuntimeError: test error
2021-01-04T22:57:58.545Z pid=27170 tid=oumufbh0i class=AtomicJob jid=5cc1fcf049c0eb148341a8e8 bid=jl82Q49lVs0oOg INFO: start
RUNNING JOB: 4
2021-01-04T22:57:58.546Z pid=27170 tid=oumufbh0i class=AtomicJob jid=5cc1fcf049c0eb148341a8e8 bid=jl82Q49lVs0oOg elapsed=0.001 INFO: done
2021-01-04T22:57:58.547Z pid=27170 tid=oumufbh0i class=AtomicJob jid=b0c5604f573b0449a155fe80 bid=jl82Q49lVs0oOg INFO: start
RUNNING JOB: 5
2021-01-04T22:57:58.550Z pid=27170 tid=oumufbh0i class=AtomicJob jid=b0c5604f573b0449a155fe80 bid=jl82Q49lVs0oOg elapsed=0.004 INFO: done
2021-01-04T22:57:58.551Z pid=27170 tid=oumufbh0i class=Sidekiq::Batch::Callback jid=e55cca5a995030fa6e4aebd6 INFO: start
2021-01-04T22:57:58.551Z pid=27170 tid=oumufbh0i class=Sidekiq::Batch::Callback jid=e55cca5a995030fa6e4aebd6 elapsed=0.0 INFO: done
2021-01-04T22:57:58.551Z pid=27170 tid=oumufbh0i class=Sidekiq::Batch::Callback jid=357f75113f671f870ad3c1a7 INFO: start
FINISHED ALL JOBS: running garbage collection
2021-01-04T22:57:58.561Z pid=27170 tid=oumufbh0i class=Sidekiq::Batch::Callback jid=357f75113f671f870ad3c1a7 elapsed=0.01 INFO: done
```
